### PR TITLE
remove xmlwf

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,22 +67,11 @@ my $ffi = FFI::Platypus->new(
 );
 ```
 
-or for xmlwf from your Perl script / module
-
-```perl
-use Alien::Expat;
-use Env qw( @PATH );
-
-unshift @PATH, Alien::Expat->bin_dir;
-system 'xmlwf', '-v';
-```
-
 # DESCRIPTION
 
-This module can be used as a prereq for XS or FFI modules that need expat or the
-command-line tool that it comes from: xmlwf.  For more detail on how to use this
-module you can see the [Alien::Build](https://metacpan.org/pod/Alien::Build) user documentation at
-[Alien::Build::Manual::AlienUser](https://metacpan.org/pod/Alien::Build::Manual::AlienUser).
+This module can be used as a prereq for XS or FFI modules that need expat.
+For more detail on how to use this module you can see the [Alien::Build](https://metacpan.org/pod/Alien::Build)
+user documentation at [Alien::Build::Manual::AlienUser](https://metacpan.org/pod/Alien::Build::Manual::AlienUser).
 
 # SEE ALSO
 

--- a/alienfile
+++ b/alienfile
@@ -2,12 +2,6 @@ use alienfile;
 
 plugin 'PkgConfig' => 'expat';
 
-plugin 'Probe::CommandLine' => (
-  command   => 'xmlwf',
-  args      => '-v',
-  secondary => 1,
-);
-
 share {
   plugin 'Download::GitHub' => (
     github_user => 'libexpat',

--- a/lib/Alien/Expat.pm
+++ b/lib/Alien/Expat.pm
@@ -65,20 +65,11 @@ or L<FFI::Platypus>:
    lib => [ Alien::Expat->dynamic_libs ],
  );
 
-or for xmlwf from your Perl script / module
-
- use Alien::Expat;
- use Env qw( @PATH );
- 
- unshift @PATH, Alien::Expat->bin_dir;
- system 'xmlwf', '-v';
-
 =head1 DESCRIPTION
 
-This module can be used as a prereq for XS or FFI modules that need expat or the
-command-line tool that it comes from: xmlwf.  For more detail on how to use this
-module you can see the L<Alien::Build> user documentation at
-L<Alien::Build::Manual::AlienUser>.
+This module can be used as a prereq for XS or FFI modules that need expat.
+For more detail on how to use this module you can see the L<Alien::Build>
+user documentation at L<Alien::Build::Manual::AlienUser>.
 
 =head1 SEE ALSO
 

--- a/t/alien_expat.t
+++ b/t/alien_expat.t
@@ -7,13 +7,6 @@ alien_diag 'Alien::Expat';
 
 alien_ok 'Alien::Expat';
 
-subtest xmlwf => sub {
-
-  run_ok(['xmlwf', '-v'])
-    ->success
-    ->note;
-};
-
 my $xs_version;
 
 subtest xs => sub {


### PR DESCRIPTION
`xmlwf` is usually packaged separately on like Debian etc. and it isn't really that useful to have it from Perl.  Removing the requirement to have xmlwf installed for system installs would probably increase the number of possible system installs.